### PR TITLE
:sparkles: Add route caching and update observers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "made-foryou/routes",
     "description": "A packages which can provide routing generated from the database.",
     "license": "MIT",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "autoload": {
         "psr-4": {
             "MadeForYou\\Routes\\": "src/"

--- a/src/Actions/RefreshRouteCacheAction.php
+++ b/src/Actions/RefreshRouteCacheAction.php
@@ -1,0 +1,48 @@
+<?php
+declare( strict_types = 1 );
+
+namespace MadeForYou\Routes\Actions;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use MadeForYou\Routes\Models\Route;
+
+class RefreshRouteCacheAction
+{
+    /**
+     * Get the cache key for the routes cache.
+     *
+     * @return string The cache key for the routes cache.
+     */
+    protected function cacheKey(): string
+    {
+        return Config::get('routes.cache_key');
+    }
+
+    /**
+     * Execute the action to refresh the route cache.
+     *
+     * @return void
+     */
+    public function execute (): void
+    {
+        Cache::forget($this->cacheKey());
+
+        Cache::rememberForever($this->cacheKey(), function () {
+            return Route::all();
+        });
+    }
+
+    /**
+     * Run the refresh route cache action.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
+    public static function run (): void
+    {
+        app()->make(RefreshRouteCacheAction::class)
+            ->execute(...func_get_args());
+    }
+}

--- a/src/Observers/RouteObserver.php
+++ b/src/Observers/RouteObserver.php
@@ -2,23 +2,19 @@
 
 namespace MadeForYou\Routes\Observers;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use MadeForYou\Routes\Actions\RefreshRouteCacheAction;
 use MadeForYou\Routes\Models\Route;
 
 class RouteObserver
 {
+    /**
+     * @throws BindingResolutionException
+     */
     public function saved(Route $route): void
     {
-        Cache::forget(self::cacheKey());
-
-        Cache::rememberForever(self::cacheKey(), function () {
-            return Route::all();
-        });
-    }
-
-    public static function cacheKey(): string
-    {
-        return Config::get('routes.cache_key');
+        RefreshRouteCacheAction::run();
     }
 }

--- a/src/Observers/WithRouteObserver.php
+++ b/src/Observers/WithRouteObserver.php
@@ -2,25 +2,59 @@
 
 namespace MadeForYou\Routes\Observers;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
+use MadeForYou\Routes\Actions\RefreshRouteCacheAction;
 use MadeForYou\Routes\Contracts\HasRoute;
 
 class WithRouteObserver
 {
+    /**
+     * Triggered when a new model is created.
+     *
+     * @param  HasRoute  $model  The newly created model.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
     public function created(HasRoute $model): void
     {
         $this->saveRoute($model);
     }
 
+    /**
+     * Invoked after a model has been updated.
+     *
+     * @param  HasRoute  $model  The model that has been updated.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
     public function updated(HasRoute $model): void
     {
         $this->saveRoute($model);
     }
 
+    /**
+     * Handles the "deleted" event for the given model.
+     *
+     * @param  HasRoute  $model  The model that was deleted.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
     public function deleted(HasRoute $model): void
     {
         $this->saveRoute($model);
     }
 
+    /**
+     * Saves the route for the given model.
+     *
+     * @param  HasRoute  $model  The model for which the route needs to be saved.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
     protected function saveRoute(HasRoute $model): void
     {
         $model->route()->updateOrCreate([
@@ -29,5 +63,7 @@ class WithRouteObserver
         ], [
             'url' => $model->getUrl(),
         ]);
+
+        RefreshRouteCacheAction::run();
     }
 }

--- a/src/Resources/RouteResource.php
+++ b/src/Resources/RouteResource.php
@@ -5,9 +5,11 @@ namespace MadeForYou\Routes\Resources;
 use Filament\Forms\Form;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use MadeForYou\Helpers\Facades\Generate;
+use MadeForYou\Routes\Actions\RefreshRouteCacheAction;
 use MadeForYou\Routes\Models\Route;
 use MadeForYou\Routes\Resources\RouteResource\ListRoutesPage;
 
@@ -45,6 +47,12 @@ class RouteResource extends Resource
                 TextColumn::make('updated_at')
                     ->label('Laatste gewijzigd op')
                     ->since(),
+            ])
+            ->headerActions([
+                Action::make('refresh_cache')
+                    ->label('Routes bijwerken')
+                    ->button()
+                    ->action(fn () => RefreshRouteCacheAction::run())
             ])
             ->defaultSort('updated_at', 'desc');
     }


### PR DESCRIPTION
This commit introduces a new RefreshRouteCacheAction that handles the cache refresh workflow for routes. Additionally, the RouteObserver and WithRouteObserver have been updated to utilize this new action during their save operations. The RouteResource has also been updated to include a header action allowing for manually triggering the cache refresh.